### PR TITLE
Support go module to build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/yuya-takeyama/ntimes
+
+go 1.14
+
+require github.com/jessevdk/go-flags v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=


### PR DESCRIPTION
Support go module to build by following command:

```bash
$ go mod init # To generate go.mod
$ go build # To generate go.sum
```

I've confirmed it can build using Go 1.14.4